### PR TITLE
Add FastMCP web search skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN pip install uv
+COPY . /app
+
+RUN uv pip install --system 'fastmcp' 'fastapi' 'uvicorn[standard]' 'httpx' 'redis'
+
+CMD ["python", "-m", "web_mcp.server"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Tag2RAG
+# Web Search MCP
+
+This repository contains an example FastMCP server that extracts and summarizes web pages.
+
+See `docs/index.md` for usage instructions in Korean.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Web Search MCP 서버
+
+이 프로젝트는 FastMCP 라이브러리를 사용하여 웹 페이지를 탐색하고 요약하는 MCP 서버의 예제입니다.
+
+## 특징
+- 비동기 작업 처리
+- Redis 기반 상태 저장
+- 외부 API 연동을 위한 `httpx` 사용
+- `data://reports/{report_id}` 형태의 동적 리소스
+- Bearer 토큰 인증 지원
+- Docker 이미지 제공
+
+## 설치
+1. [uv](https://github.com/astral-sh/uv) 로 가상환경 생성
+```bash
+uv venv .venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+## 실행
+```bash
+export FASTMCP_AUTH_BEARER_PUBLIC_KEY=<PUBLIC_KEY>
+python -m web_mcp.server
+```
+
+## Docker 사용
+```bash
+docker build -t web-mcp .
+docker run -p 8000:8000 -e FASTMCP_AUTH_BEARER_PUBLIC_KEY=<PUBLIC_KEY> web-mcp
+```
+
+## 제공되는 툴
+- `list_pages(url)` : 하위 페이지를 재귀적으로 탐색하여 URL 목록을 반환합니다.
+- `page_intro(url)` : 해당 페이지의 한 줄 소개를 반환합니다.
+- `page_summary(url)` : RAG 입력을 위한 요약을 생성합니다.
+
+각 알고리즘의 상세 로직은 `src/web_mcp/tools.py`에서 구현하면 됩니다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "web_mcp"
+version = "0.1.0"
+description = "Web search MCP server"
+authors = [{name = "Example"}]
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "fastmcp",
+    "fastapi",
+    "uvicorn[standard]",
+    "httpx",
+    "redis",
+]
+
+[project.optional-dependencies]
+dev = [
+    "sphinx",
+    "myst-parser"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastmcp
+fastapi
+uvicorn[standard]
+httpx
+redis

--- a/src/web_mcp/__init__.py
+++ b/src/web_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Web Search MCP package."""
+
+from .server import create_server
+
+__all__ = ["create_server"]

--- a/src/web_mcp/resources.py
+++ b/src/web_mcp/resources.py
@@ -1,0 +1,16 @@
+"""Dynamic resource generation for reports."""
+
+
+import json
+
+from fastmcp.server.context import Context
+
+
+def generate_report(report_id: str, ctx: Context) -> bytes:
+    """Return a JSON report for the given identifier.
+
+    The actual report creation logic should be implemented here.
+    """
+    ctx.info(f"Generating report {report_id}")
+    data = {"id": report_id, "summary": "TODO"}
+    return json.dumps(data).encode("utf-8")

--- a/src/web_mcp/server.py
+++ b/src/web_mcp/server.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+
+import redis.asyncio as redis
+from fastmcp.server import FastMCP
+from fastmcp.server.auth.providers.bearer_env import EnvBearerAuthProvider
+
+from . import tools, resources
+
+
+@asynccontextmanager
+async def lifespan(app: FastMCP):
+    """Manage application lifespan and shared resources."""
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    r = redis.from_url(redis_url)
+    try:
+        yield {"redis": r}
+    finally:
+        await r.aclose()
+
+
+def create_server() -> FastMCP:
+    """Create and configure the FastMCP server."""
+    app = FastMCP(
+        name="WebSearchMCP",
+        instructions="웹 페이지 추출 및 요약 MCP",
+        auth=EnvBearerAuthProvider(),
+        lifespan=lifespan,
+        cache_expiration_seconds=300,
+    )
+
+    app.add_tool(tools.list_pages)
+    app.add_tool(tools.page_intro)
+    app.add_tool(tools.page_summary)
+
+    app.resource("data://reports/{report_id}")(resources.generate_report)
+
+    return app
+
+
+def main() -> None:
+    app = create_server()
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    app.run("http", host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/web_mcp/tools.py
+++ b/src/web_mcp/tools.py
@@ -1,0 +1,28 @@
+"""Placeholder tool implementations for the WebSearchMCP."""
+
+from fastmcp.tools import Tool
+import httpx
+
+
+@Tool.from_function
+async def list_pages(url: str) -> list[str]:
+    """Explore subpages of the given URL and return a list.
+
+    TODO: implement the actual crawling algorithm.
+    """
+    # Placeholder implementation
+    async with httpx.AsyncClient() as client:
+        await client.get(url)
+    return []
+
+
+@Tool.from_function
+async def page_intro(url: str) -> str:
+    """Return a one-line introduction of the web page."""
+    return ""
+
+
+@Tool.from_function
+async def page_summary(url: str) -> str:
+    """Return a summary for RAG input."""
+    return ""


### PR DESCRIPTION
## Summary
- initialize FastMCP based web search server
- add placeholder tools and dynamic report resource
- provide Dockerfile and project metadata
- document usage in Korean

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m web_mcp.server --help`

------
https://chatgpt.com/codex/tasks/task_e_68750a5f5bac832cb7885623852016c6